### PR TITLE
Custom link attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Scalable Capital Changes
 
 - Fixes a bug with system fonts (as proposed in [this PR](https://github.com/SimonFairbairn/SwiftyMarkdown/pull/100))
+  - Included also support for custom font weight
 - Adds the ability to ignore dynamic type
+- Adds support for custom link attribute
 
 # SwiftyMarkdown 1.0
 

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
@@ -122,9 +122,11 @@ extension SwiftyMarkdown {
 			if existentFontName.hasPrefix(".SFUI") {
 				let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
                 if ignoresDynamicSize {
-                    font = UIFont.systemFont(ofSize: finalSize)
+                    font = UIFont.systemFont(ofSize: finalSize, weight: fontWeightFromSystemFont(name: existentFontName))
+
                 } else {
-                    font = fontMetrics.scaledFont(for: UIFont.systemFont(ofSize: finalSize))
+                    font = fontMetrics.scaledFont(for: UIFont.systemFont(ofSize: finalSize, weight: fontWeightFromSystemFont(name: existentFontName))
+)
                 }
 			} else if let customFont = UIFont(name: existentFontName, size: finalSize)  {
 				let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
@@ -180,6 +182,22 @@ extension SwiftyMarkdown {
 			return link.color
 		}
 	}
+    
+    private func fontWeightFromSystemFont(name: String) -> UIFont.Weight {
+        switch name.split(separator: "-").last {
+        case "Black": return .black
+        case "Bold": return .bold
+        case "Heavy": return .heavy
+        case "Light": return .light
+        case "Medium": return .medium
+        case "Regular": return .regular
+        case "Semibold": return .semibold
+        case "Thin": return .thin
+        case "Ultralight": return .ultraLight
+        default:
+            return .regular
+        }
+    }
 	
 }
 #endif

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -249,6 +249,9 @@ If that is not set, then the system default will be used.
 	public var bullet : String = "・"
 	
 	public var underlineLinks : Bool = false
+    
+    /// The attribute that will store the url string for links
+    public var linkAttribute: NSAttributedString.Key = .link
 	
 	public var frontMatterAttributes : [String : String] {
 		get {
@@ -574,7 +577,7 @@ extension SwiftyMarkdown {
             if let linkIdx = styles.firstIndex(of: .link), linkIdx < token.metadataStrings.count {
                 attributes[.foregroundColor] = self.link.color
                 attributes[.font] = self.font(for: line, characterOverride: .link)
-                attributes[.link] = token.metadataStrings[linkIdx] as AnyObject
+                attributes[linkAttribute] = token.metadataStrings[linkIdx] as AnyObject
                 
                 if underlineLinks {
                     attributes[.underlineStyle] = self.link.underlineStyle.rawValue as AnyObject


### PR DESCRIPTION
#### Use correct font weight for system fonts
when using system fonts, the api was used without specifying the font weight, which will then always use `regular` font weight.

#### Added support for a custom link attribute
when using the default `link` attribute for storing the url string, on normal UILabels the system will format it with the default link style which cannot be overridden with custom font/color attributes