### PR TITLE
Fixed bold + italic annotation

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+iOS.swift
@@ -13,7 +13,11 @@ import UIKit
 
 extension SwiftyMarkdown {
 	
-	func font( for line : SwiftyLine, characterOverride : CharacterStyle? = nil ) -> UIFont {
+    func font( for line : SwiftyLine, characterOverride : CharacterStyle? = nil ) -> UIFont {
+        font(for: line, characterOverrides: characterOverride == nil ? [] : [characterOverride!])
+    }
+    
+    func font( for line : SwiftyLine, characterOverrides : [CharacterStyle]) -> UIFont {
 		let textStyle : UIFont.TextStyle
 		var fontName : String?
 		var fontSize : CGFloat?
@@ -83,7 +87,7 @@ extension SwiftyMarkdown {
 			fontName = body.fontName
 		}
 		
-		if let characterOverride = characterOverride {
+        for characterOverride in characterOverrides {
 			switch characterOverride {
 			case .code:
 				fontName = code.fontName ?? fontName
@@ -142,12 +146,13 @@ extension SwiftyMarkdown {
 			font = UIFont.preferredFont(forTextStyle: textStyle)
 		}
 		
-		if globalItalic, let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.traitItalic) {
-			font = UIFont(descriptor: italicDescriptor, size: 0)
-		}
-		if globalBold, let boldDescriptor = font.fontDescriptor.withSymbolicTraits(.traitBold) {
-			font = UIFont(descriptor: boldDescriptor, size: 0)
-		}
+        if globalItalic, globalBold, let boldItalicDescriptor = font.fontDescriptor.withSymbolicTraits([.traitItalic, .traitBold]) {
+            font = UIFont(descriptor: boldItalicDescriptor, size: 0)
+        } else if globalBold, let boldDescriptor = font.fontDescriptor.withSymbolicTraits(.traitBold) {
+            font = UIFont(descriptor: boldDescriptor, size: 0)
+        } else if globalItalic, let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.traitItalic) {
+            font = UIFont(descriptor: italicDescriptor, size: 0)
+        }
 		
 		return font
 		

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown+macOS.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown+macOS.swift
@@ -11,8 +11,11 @@ import Foundation
 import AppKit
 
 extension SwiftyMarkdown {
-	
-	func font( for line : SwiftyLine, characterOverride : CharacterStyle? = nil ) -> NSFont {
+    func font( for line : SwiftyLine, characterOverride : CharacterStyle? = nil ) -> NSFont {
+        font(for: line, characterOverrides: characterOverride == nil ? [] : [characterOverride!])
+    }
+    
+    func font( for line : SwiftyLine, characterOverrides : [CharacterStyle]) -> NSFont {
 		var fontName : String?
 		var fontSize : CGFloat?
 		
@@ -60,7 +63,7 @@ extension SwiftyMarkdown {
 			fontName = body.fontName
 		}
 		
-		if let characterOverride = characterOverride {
+        for characterOverride in characterOverrides {
 			switch characterOverride {
 			case .code:
 				fontName = code.fontName ?? fontName
@@ -99,14 +102,16 @@ extension SwiftyMarkdown {
 			font = NSFont.systemFont(ofSize: finalSize)
 		}
 		
-		if globalItalic {
-			let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.italic)
-			font = NSFont(descriptor: italicDescriptor, size: 0) ?? font
-		}
-		if globalBold {
-			let boldDescriptor = font.fontDescriptor.withSymbolicTraits(.bold)
-			font = NSFont(descriptor: boldDescriptor, size: 0) ?? font
-		}
+        if globalItalic, globalBold {
+            let boldItalicDescriptor = font.fontDescriptor.withSymbolicTraits([.italic, .bold])
+            font = NSFont(descriptor: boldItalicDescriptor, size: 0) ?? font
+        } else if globalBold {
+            let boldDescriptor = font.fontDescriptor.withSymbolicTraits(.bold)
+            font = NSFont(descriptor: boldDescriptor, size: 0) ?? font
+        } else if globalItalic {
+            let italicDescriptor = font.fontDescriptor.withSymbolicTraits(.italic)
+            font = NSFont(descriptor: italicDescriptor, size: 0) ?? font
+        }
 		
 		return font
 		


### PR DESCRIPTION
It was not possible to create ***"bold italic"*** formatting (`***blabla***`) even though it is listed as supported in the documentation. Fixed the issue 