### PR TITLE
Added option for easier custom styling with `.color` and `.font` CharacterStyles

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -17,7 +17,7 @@ extension OSLog {
 	static let swiftyMarkdownPerformance = OSLog(subsystem: subsystem, category: "Swifty Markdown Performance")
 }
 
-public enum CharacterStyle : CharacterStyling {
+public enum CharacterStyle : CharacterStyling, Equatable {
 	case none
 	case bold
 	case italic
@@ -27,12 +27,45 @@ public enum CharacterStyle : CharacterStyling {
 	case referencedLink
 	case referencedImage
 	case strikethrough
+    #if os(macOS)
+    case color(color: NSColor)
+    case font(font: NSFont)
+    #else
+    case color(color: UIColor)
+    case font(font: UIFont)
+    #endif
 	
 	public func isEqualTo(_ other: CharacterStyling) -> Bool {
 		guard let other = other as? CharacterStyle else {
 			return false
 		}
-		return other == self 
+        
+        switch (self, other) {
+        case (.color, .color):
+            return true
+        case (.font, .font):
+            return true
+        case (.none, .none):
+            return true
+        case (.bold, .bold):
+            return true
+        case (.italic, .italic):
+            return true
+        case (.code, .code):
+            return true
+        case (.link, .link):
+            return true
+        case (.image, .image):
+            return true
+        case (.referencedLink, .referencedLink):
+            return true
+        case (.referencedImage, .referencedImage):
+            return true
+        case (.strikethrough, .strikethrough):
+            return true
+        default:
+            return false
+        }
 	}
 }
 
@@ -446,11 +479,7 @@ If that is not set, then the system default will be used.
 		return attributedString
 	}
 	
-}
-
-extension SwiftyMarkdown {
-	
-	func attributedStringFor( tokens : [Token], in line : SwiftyLine ) -> NSAttributedString {
+	open func attributedStringFor( tokens : [Token], in line : SwiftyLine ) -> NSAttributedString {
 		
 		var finalTokens = tokens
 		let finalAttributedString = NSMutableAttributedString()
@@ -616,13 +645,73 @@ extension SwiftyMarkdown {
 			if styles.contains(.code) {
 				attributes[.foregroundColor] = self.code.color
 				attributes[.font] = self.font(for: line, characterOverride: .code)
-			} else {
-				// Switch back to previous font
 			}
+            
+            if let color = styles.colorStyle {
+                attributes[.foregroundColor] = color
+            }
+            
+            if let font = styles.fontStyle {
+                attributes[.font] = font
+            } else {
+                // Switch back to previous font
+            }
 			let str = NSAttributedString(string: token.outputString, attributes: attributes)
 			finalAttributedString.append(str)
 		}
 	
 		return finalAttributedString
 	}
+}
+
+private extension CharacterStyle {
+    #if os(macOS)
+    var color: NSColor? {
+        if case .color(let color) = self {
+            return color
+        }
+        return nil
+    }
+    
+    var font: NSFont? {
+        if case .font(let font) = self {
+            return font
+        }
+        return nil
+    }
+    #else
+    var color: UIColor? {
+        if case .color(let color) = self {
+            return color
+        }
+        return nil
+    }
+    
+    var font: UIFont? {
+        if case .font(let font) = self {
+            return font
+        }
+        return nil
+    }
+    #endif
+}
+
+private extension Array where Element == CharacterStyle {
+    #if os(macOS)
+    var colorStyle: NSColor? {
+        return self.first(where: { $0.color != nil })?.color
+    }
+    
+    var fontStyle: NSFont? {
+        return self.first(where: { $0.font != nil })?.font
+    }
+    #else
+    var colorStyle: UIColor? {
+        return self.first(where: { $0.color != nil })?.color
+    }
+    
+    var fontStyle: UIFont? {
+        return self.first(where: { $0.font != nil })?.font
+    }
+    #endif
 }

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -40,7 +40,11 @@ public enum CharacterStyle : CharacterStyling, Equatable {
 			return false
 		}
         
-        switch (self, other) {
+        return self == other
+	}
+    
+    public static func == (lhs: CharacterStyle, rhs: CharacterStyle) -> Bool {
+        switch (lhs, rhs) {
         case (.color, .color):
             return true
         case (.font, .font):
@@ -66,7 +70,7 @@ public enum CharacterStyle : CharacterStyling, Equatable {
         default:
             return false
         }
-	}
+    }
 }
 
 enum MarkdownLineStyle : LineStyling {

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -27,50 +27,50 @@ public enum CharacterStyle : CharacterStyling, Equatable {
 	case referencedLink
 	case referencedImage
 	case strikethrough
-    #if os(macOS)
-    case color(color: NSColor)
-    case font(font: NSFont)
-    #else
-    case color(color: UIColor)
-    case font(font: UIFont)
-    #endif
+	#if os(macOS)
+	case color(color: NSColor)
+	case font(font: NSFont)
+	#else
+	case color(color: UIColor)
+	case font(font: UIFont)
+	#endif
 	
 	public func isEqualTo(_ other: CharacterStyling) -> Bool {
 		guard let other = other as? CharacterStyle else {
 			return false
 		}
-        
-        return self == other
+		
+		return self == other
 	}
-    
-    public static func == (lhs: CharacterStyle, rhs: CharacterStyle) -> Bool {
-        switch (lhs, rhs) {
-        case (.color, .color):
-            return true
-        case (.font, .font):
-            return true
-        case (.none, .none):
-            return true
-        case (.bold, .bold):
-            return true
-        case (.italic, .italic):
-            return true
-        case (.code, .code):
-            return true
-        case (.link, .link):
-            return true
-        case (.image, .image):
-            return true
-        case (.referencedLink, .referencedLink):
-            return true
-        case (.referencedImage, .referencedImage):
-            return true
-        case (.strikethrough, .strikethrough):
-            return true
-        default:
-            return false
-        }
-    }
+	
+	public static func == (lhs: CharacterStyle, rhs: CharacterStyle) -> Bool {
+		switch (lhs, rhs) {
+		case (.color, .color):
+			return true
+		case (.font, .font):
+			return true
+		case (.none, .none):
+			return true
+		case (.bold, .bold):
+			return true
+		case (.italic, .italic):
+			return true
+		case (.code, .code):
+			return true
+		case (.link, .link):
+			return true
+		case (.image, .image):
+			return true
+		case (.referencedLink, .referencedLink):
+			return true
+		case (.referencedImage, .referencedImage):
+			return true
+		case (.strikethrough, .strikethrough):
+			return true
+		default:
+			return false
+		}
+	}
 }
 
 enum MarkdownLineStyle : LineStyling {
@@ -650,16 +650,16 @@ If that is not set, then the system default will be used.
 				attributes[.foregroundColor] = self.code.color
 				attributes[.font] = self.font(for: line, characterOverride: .code)
 			}
-            
-            if let color = styles.colorStyle {
-                attributes[.foregroundColor] = color
-            }
-            
-            if let font = styles.fontStyle {
-                attributes[.font] = font
-            } else {
-                // Switch back to previous font
-            }
+			
+			if let color = styles.colorStyle {
+				attributes[.foregroundColor] = color
+			}
+			
+			if let font = styles.fontStyle {
+				attributes[.font] = font
+			} else {
+				// Switch back to previous font
+			}
 			let str = NSAttributedString(string: token.outputString, attributes: attributes)
 			finalAttributedString.append(str)
 		}


### PR DESCRIPTION
`SwiftyMarkdown` has the possibility to define custom tags. However you can only use preexisting `CharacterStyles`  and you can only use a single character style per tag (not for example bold + italic). I added two more `CharacterStyles` to be able to customize colors and fonts and opened the existing method `attributedStringFor( tokens : [Token], in line : SwiftyLine )` for overriding.

This eventually enables stuff like this:
![Simulator Screen Shot - iPhone 12 - 2021-06-14 at 11 26 34](https://user-images.githubusercontent.com/717301/121870515-6cddc000-cd03-11eb-8334-a5b9309dc336.png)
