### PR TITLE
[Bug] Fix Indentation for (Un-) Ordered Lists

### DIFF
--- a/Example/SwiftyMarkdownExample.xcodeproj/project.pbxproj
+++ b/Example/SwiftyMarkdownExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -626,6 +626,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = SwiftyMarkdownExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -642,6 +643,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = SwiftyMarkdownExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/SwiftyMarkdownExample/Base.lproj/LaunchScreen.storyboard
+++ b/Example/SwiftyMarkdownExample/Base.lproj/LaunchScreen.storyboard
@@ -1,7 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -13,10 +16,9 @@
                         <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Example/SwiftyMarkdownExample/ViewController.swift
+++ b/Example/SwiftyMarkdownExample/ViewController.swift
@@ -37,9 +37,9 @@ class ViewController: UIViewController {
 		
 		if let url = Bundle.main.url(forResource: "example", withExtension: "md"), let md = SwiftyMarkdown(url: url) {
 			md.h2.fontName = "AvenirNextCondensed-Bold"
-			md.h2.color = UIColor.blue
-			md.h2.alignment = .center
-			
+            md.bullet = "• "
+            md.tabStopsInterval = 12
+
 			md.code.fontName = "CourierNewPSMT"
 			
 

--- a/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
+++ b/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
@@ -124,7 +124,14 @@ public class SwiftyLineProcessor {
 			if let hasToken = self.closeToken, unprocessed != hasToken {
 				return nil
 			}
-            element.token = element.token.replacingOccurrences(of: "\t", with: "    ")
+
+            if element.removeFrom == .leading {
+                let prefix = text.prefix(where: { $0 == " "})
+                if !prefix.isEmpty {
+                    element.token = element.token.replacingOccurrences(of: "\t", with: prefix)
+                }
+            }
+
 			if !text.contains(element.token) {
 				continue
 			}
@@ -246,4 +253,17 @@ public class SwiftyLineProcessor {
     
 }
 
+private extension String {
+    func prefix(where predicate: (Character) -> Bool) -> String {
+        var result = ""
+        for char in self {
+            if predicate(char) {
+                result.append(char)
+            } else {
+                break
+            }
+        }
+        return result
+    }
+}
 

--- a/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
+++ b/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
@@ -54,7 +54,7 @@ public struct FrontMatterRule {
 }
 
 public struct LineRule {
-    let token : String
+    var token : String
     let removeFrom : Remove
     let type : LineStyling
     let shouldTrim : Bool
@@ -114,7 +114,7 @@ public class SwiftyLineProcessor {
         }
         let previousLines = lineRules.filter({ $0.changeAppliesTo == .previous })
 
-        for element in lineRules {
+        for var element in lineRules {
             guard element.token.count > 0 else {
                 continue
             }
@@ -124,7 +124,7 @@ public class SwiftyLineProcessor {
 			if let hasToken = self.closeToken, unprocessed != hasToken {
 				return nil
 			}
-            
+            element.token = element.token.replacingOccurrences(of: "\t", with: "    ")
 			if !text.contains(element.token) {
 				continue
 			}

--- a/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
+++ b/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
@@ -73,7 +73,8 @@ public class SwiftyLineProcessor {
     
 	public var processEmptyStrings : LineStyling?
 	public internal(set) var frontMatterAttributes : [String : String] = [:]
-	
+
+    var prefixToken: String? = nil
 	var closeToken : String? = nil
     let defaultType : LineStyling
     
@@ -128,7 +129,8 @@ public class SwiftyLineProcessor {
             if element.removeFrom == .leading {
                 let prefix = text.prefix(where: { $0 == " "})
                 if !prefix.isEmpty {
-                    element.token = element.token.replacingOccurrences(of: "\t", with: prefix)
+                    element.token = element.token.replacingOccurrences(of: "\t", with: prefixToken ?? prefix)
+                    self.prefixToken = prefix
                 }
             }
 
@@ -159,8 +161,11 @@ public class SwiftyLineProcessor {
 				return nil
 			}
 
-			
-			
+            // Reset prefix token, in case we are not in a first or second order list anymore
+            if let style = element.type as? MarkdownLineStyle, !style.isListItem {
+                prefixToken = nil
+            }
+
             output = (element.shouldTrim) ? output.trimmingCharacters(in: .whitespaces) : output
             return SwiftyLine(line: output, lineStyle: element.type)
             

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -192,17 +192,17 @@ If that is not set, then the system default will be used.
 		FrontMatterRule(openTag: "---", closeTag: "---", keyValueSeparator: ":")
 	]
 	
-	static public var lineRules = [
+    static public var lineRules: [LineRule] = [
 		LineRule(token: "=", type: MarkdownLineStyle.previousH1, removeFrom: .entireLine, changeAppliesTo: .previous),
 		LineRule(token: "-", type: MarkdownLineStyle.previousH2, removeFrom: .entireLine, changeAppliesTo: .previous),
-		LineRule(token: "\t\t- ", type: MarkdownLineStyle.unorderedListIndentSecondOrder, removeFrom: .leading, shouldTrim: false),
-		LineRule(token: "\t- ", type: MarkdownLineStyle.unorderedListIndentFirstOrder, removeFrom: .leading, shouldTrim: false),
-		LineRule(token: "- ",type : MarkdownLineStyle.unorderedList, removeFrom: .leading),
+
+        LineRule(token: "\t\t- ", type: MarkdownLineStyle.unorderedListIndentSecondOrder, removeFrom: .leading, shouldTrim: false),
+        LineRule(token: "\t- ", type: MarkdownLineStyle.unorderedListIndentFirstOrder, removeFrom: .leading, shouldTrim: false),
+        LineRule(token: "- ",type : MarkdownLineStyle.unorderedList, removeFrom: .leading),
+
 		LineRule(token: "\t\t* ", type: MarkdownLineStyle.unorderedListIndentSecondOrder, removeFrom: .leading, shouldTrim: false),
 		LineRule(token: "\t* ", type: MarkdownLineStyle.unorderedListIndentFirstOrder, removeFrom: .leading, shouldTrim: false),
 		LineRule(token: "* ",type : MarkdownLineStyle.unorderedList, removeFrom: .leading),
-		LineRule(token: "    ", type: MarkdownLineStyle.codeblock, removeFrom: .leading, shouldTrim: false),
-		LineRule(token: "\t", type: MarkdownLineStyle.codeblock, removeFrom: .leading, shouldTrim: false),
 		LineRule(token: ">",type : MarkdownLineStyle.blockquote, removeFrom: .leading),
 		LineRule(token: "###### ",type : MarkdownLineStyle.h6, removeFrom: .both),
 		LineRule(token: "##### ",type : MarkdownLineStyle.h5, removeFrom: .both),
@@ -213,11 +213,11 @@ If that is not set, then the system default will be used.
 	]
 
     static public var orderedListRules: [LineRule] {
-        return (0...100).flatMap {
+        return (1...100).flatMap {
             [
-                LineRule(token: "\($0). ", type: MarkdownLineStyle.orderedList, removeFrom: .leading),
-                LineRule(token: "\t\($0). ", type: MarkdownLineStyle.orderedList, removeFrom: .leading),
-                LineRule(token: "\t\t\($0). ", type: MarkdownLineStyle.orderedList, removeFrom: .leading)
+                LineRule(token: "\t\t\($0). ", type: MarkdownLineStyle.orderedListIndentSecondOrder, removeFrom: .leading, shouldTrim: false),
+                LineRule(token: "\t\($0). ", type: MarkdownLineStyle.orderedListIndentFirstOrder, removeFrom: .leading, shouldTrim: false),
+                LineRule(token: "\($0). ", type: MarkdownLineStyle.orderedList, removeFrom: .leading)
             ]
         }
     }
@@ -293,6 +293,9 @@ If that is not set, then the system default will be used.
 	public var bullet : String = "・"
 	
     public var tabStopsInterval : CGFloat = 30
+
+    // The spacing between entries in an ordered or unordered list
+    public var listSpacing: CGFloat = 0
 
     public var underlineLinks : Bool = false
     
@@ -521,7 +524,6 @@ If that is not set, then the system default will be used.
 			}
 			
 		default:
-            guard !line.line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { break }
 			self.orderedListCount = 0
 			self.orderedListIndentFirstOrderCount = 0
 			self.orderedListIndentSecondOrderCount = 0
@@ -555,15 +557,15 @@ If that is not set, then the system default will be used.
 		case .unorderedList, .unorderedListIndentFirstOrder, .unorderedListIndentSecondOrder, .orderedList, .orderedListIndentFirstOrder, .orderedListIndentSecondOrder:
 			
 			let interval : CGFloat = tabStopsInterval
-			var addition = interval
+			var addition = interval * 2
 			var indent = ""
 			switch line.lineStyle as! MarkdownLineStyle {
 			case .unorderedListIndentFirstOrder, .orderedListIndentFirstOrder:
-				addition = interval * 2
-				indent = "\t"
-			case .unorderedListIndentSecondOrder, .orderedListIndentSecondOrder:
-				addition = interval * 3
+				addition = interval * 4
 				indent = "\t\t"
+			case .unorderedListIndentSecondOrder, .orderedListIndentSecondOrder:
+				addition = interval * 6
+				indent = "\t\t\t"
 			default:
 				break
 			}
@@ -574,10 +576,12 @@ If that is not set, then the system default will be used.
 			paragraphStyle.tabStops = [NSTextTab(textAlignment: .left, location: interval, options: [:]), NSTextTab(textAlignment: .left, location: interval, options: [:])]
 			paragraphStyle.defaultTabInterval = interval
 			paragraphStyle.headIndent = addition
+            paragraphStyle.firstLineHeadIndent = 0
+            paragraphStyle.paragraphSpacingBefore = listSpacing
 
 			attributes[.paragraphStyle] = paragraphStyle
-			finalTokens.insert(Token(type: .string, inputString: "\(indent)\(listItem)\t"), at: 0)
-			
+			finalTokens.insert(Token(type: .string, inputString: "\(indent)\(listItem) \t"), at: 0)
+
 		case .yaml:
 			lineProperties = body
 		case .previousH1:

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -200,9 +200,6 @@ If that is not set, then the system default will be used.
 		LineRule(token: "- ",type : MarkdownLineStyle.unorderedList, removeFrom: .leading),
 		LineRule(token: "\t\t* ", type: MarkdownLineStyle.unorderedListIndentSecondOrder, removeFrom: .leading, shouldTrim: false),
 		LineRule(token: "\t* ", type: MarkdownLineStyle.unorderedListIndentFirstOrder, removeFrom: .leading, shouldTrim: false),
-		LineRule(token: "\t\t1. ", type: MarkdownLineStyle.orderedListIndentSecondOrder, removeFrom: .leading, shouldTrim: false),
-		LineRule(token: "\t1. ", type: MarkdownLineStyle.orderedListIndentFirstOrder, removeFrom: .leading, shouldTrim: false),
-		LineRule(token: "1. ",type : MarkdownLineStyle.orderedList, removeFrom: .leading),
 		LineRule(token: "* ",type : MarkdownLineStyle.unorderedList, removeFrom: .leading),
 		LineRule(token: "    ", type: MarkdownLineStyle.codeblock, removeFrom: .leading, shouldTrim: false),
 		LineRule(token: "\t", type: MarkdownLineStyle.codeblock, removeFrom: .leading, shouldTrim: false),
@@ -214,7 +211,17 @@ If that is not set, then the system default will be used.
 		LineRule(token: "## ",type : MarkdownLineStyle.h2, removeFrom: .both),
 		LineRule(token: "# ",type : MarkdownLineStyle.h1, removeFrom: .both)
 	]
-	
+
+    static public var orderedListRules: [LineRule] {
+        return (0...100).flatMap {
+            [
+                LineRule(token: "\($0). ", type: MarkdownLineStyle.orderedList, removeFrom: .leading),
+                LineRule(token: "\t\($0). ", type: MarkdownLineStyle.orderedList, removeFrom: .leading),
+                LineRule(token: "\t\t\($0). ", type: MarkdownLineStyle.orderedList, removeFrom: .leading)
+            ]
+        }
+    }
+
 	static public var characterRules = [
 		CharacterRule(primaryTag: CharacterRuleTag(tag: "![", type: .open), otherTags: [
 				CharacterRuleTag(tag: "]", type: .close),
@@ -242,7 +249,7 @@ If that is not set, then the system default will be used.
 		CharacterRule(primaryTag: CharacterRuleTag(tag: "_", type: .repeating), otherTags: [], styles: [1 : CharacterStyle.italic, 2 : CharacterStyle.bold], minTags:1 , maxTags:2)
 	]
 	
-	let lineProcessor = SwiftyLineProcessor(rules: SwiftyMarkdown.lineRules, defaultRule: MarkdownLineStyle.body, frontMatterRules: SwiftyMarkdown.frontMatterRules)
+    let lineProcessor = SwiftyLineProcessor(rules: SwiftyMarkdown.lineRules + SwiftyMarkdown.orderedListRules, defaultRule: MarkdownLineStyle.body, frontMatterRules: SwiftyMarkdown.frontMatterRules)
 	let tokeniser = SwiftyTokeniser(with: SwiftyMarkdown.characterRules)
 	
 	/// The styles to apply to any H1 headers found in the Markdown
@@ -514,6 +521,7 @@ If that is not set, then the system default will be used.
 			}
 			
 		default:
+            guard !line.line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { break }
 			self.orderedListCount = 0
 			self.orderedListIndentFirstOrderCount = 0
 			self.orderedListIndentSecondOrderCount = 0

--- a/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
+++ b/Sources/SwiftyMarkdown/SwiftyMarkdown.swift
@@ -113,6 +113,14 @@ enum MarkdownLineStyle : LineStyling {
             return nil
         }
     }
+
+    var isListItem: Bool {
+        switch self {
+        case .unorderedListIndentFirstOrder, .unorderedListIndentSecondOrder, .orderedListIndentFirstOrder, .orderedListIndentSecondOrder:
+            return true
+        default: return false
+        }
+    }
 }
 
 @objc public enum FontStyle : Int {
@@ -565,7 +573,7 @@ If that is not set, then the system default will be used.
 				indent = "\t\t"
 			case .unorderedListIndentSecondOrder, .orderedListIndentSecondOrder:
 				addition = interval * 6
-				indent = "\t\t\t"
+				indent = "\t\t\t\t"
 			default:
 				break
 			}


### PR DESCRIPTION
## Description

There is currently a bug in the library when it comes to handling list and especially nested lists which causes wrong indentation and overall doesn't look very nice. The main reason identified for it was that tab spaces were not correctly recognised.

Before | After
--- | --- 
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-04 at 09 22 05" src="https://github.com/user-attachments/assets/0acd23b0-d66a-4ee5-bec6-c0b64f4279e1" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-04 at 16 54 02" src="https://github.com/user-attachments/assets/2330b7da-5c34-4e2b-ad96-d1445bf16bbd" />

## Notes
There are a few shortcomings in this implementation. This solution works for our default tabstop interval but quickly breaks when another interval is used. Due to the implementation of the indentation logic, changing this is unfortunately not trivial. Hence the fix only for our use case.

You can use the following text and replace the `example.md` content with it, to reproduce the text in the screenshots.
<details>

<summary> Markdown Text </summary>

```markdown
## Unordered List Example

- This is the first main item in the unordered list, and it provides a longer description to illustrate how text wraps and displays.
  - This is the second subitem under the first main item, showing that you can add more information here as well.
    - This is the second subitem under the first main item, showing that you can add more information here as well.
- This is the second main item in the unordered list, with additional text to show how the formatting works for longer content.

---

## Ordered List Example

1. This is the first main item in the ordered list, and it contains more descriptive text to highlight how markdown handles longer content in lists.
    1. This is the first subitem under the first ordered item, with a longer sentence to show wrapping.
    2. This is the second subitem under the first ordered item, further elaborating on the example structure.
2. This is the second main item in the ordered list, and it also includes additional explanatory text for demonstration.
    1. This is the first subitem under the second ordered item, illustrating how nested lists appear when the text is extended.
    2. This is the second subitem under the second ordered item, with further content to ensure clarity for viewers.

---
```

</details>
